### PR TITLE
ci(vscode): fix extension publishing workflow

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,6 +1,8 @@
 name: Publish VS Code Extension
 
 on:
+  release:
+    types: [published]
   push:
     tags:
       - 'containless-extension-v*'
@@ -8,10 +10,14 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Only run for extension releases (skip CLI-only releases)
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'containless-extension-v'))
 
     permissions:
       contents: read
-    
+
     defaults:
       run:
         working-directory: ./vscode-extension
@@ -28,10 +34,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
       - name: Build extension
         run: npm run build
 
       - name: Publish to VS Code Marketplace
-        run: npx @vscode/vsce publish
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: vsce publish -p ${{ secrets.VSCE_PAT }}

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -7,3 +7,4 @@ node_modules/
 **/*.ts
 .vscode/
 package-lock.json
+*.vsix


### PR DESCRIPTION
## Description
This PR fixes issues with the automated publishing workflow for the VS Code extension that were causing releases to fail. It addresses missing dependencies in the CI environment, improves reliability of the authentication token, broadens the CI triggers, and prevents legacy VSIX artifacts from bloating new releases.

## Changes Made
### CI/CD Workflow (`.github/workflows/publish-extension.yml`)
- **Explicit vsce installation:** Added a step to explicitly install `@vscode/vsce` globally (`npm install -g @vscode/vsce`). Previously, relying on `npx @vscode/vsce publish` without it being in `devDependencies` caused execution failures.
- **Improved PAT passing:** Changed the publish command to use the `-p` flag (`vsce publish -p ${{ secrets.VSCE_PAT }}`) which is more reliable than passing the token solely via environment variables.
- **Expanded Triggers:** Added a trigger for GitHub Releases (`release: types: [published]`). It includes a condition to ensure it only runs for extension releases (tags starting with `containless-extension-v`), allowing you to publish directly by creating a release in the GitHub UI.

### Packaging (`vscode-extension/.vscodeignore`)
- **Ignore `.vsix` files:** Added `*.vsix` to the `.vscodeignore` list. This prevents older packaged extensions from being bundled inside the new `.vsix` archive, which can cause the marketplace to reject the upload due to file size limits.

## Verification
- Verified workflow triggers correctly parse event names and tag configurations.
- Ensured `vsce` is installed prior to the build and publish steps.
